### PR TITLE
Error message update: when occumbData object has values larger than maximum integer value

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Version: 1.1.0.9001
 Authors@R: c(
     person("Keiichi", "Fukaya", , "fukayak99@gmail.com", role = c("aut", "cre")),
     person("Ken", "Kellner", role = "cph",
-           comment = "summary method for occumbFit class")
+           comment = "summary method for occumbFit class"),
+    person("Mika", "Takahashi", role = "cre")
   )
 Description: Fits multispecies site occupancy models to environmental DNA
     metabarcoding data collected using spatially-replicated survey design.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Authors@R: c(
     person("Keiichi", "Fukaya", , "fukayak99@gmail.com", role = c("aut", "cre")),
     person("Ken", "Kellner", role = "cph",
            comment = "summary method for occumbFit class"),
-    person("Mika", "Takahashi", role = "cre")
+    person("Mika", "Takahashi", , "takahashi-mika@nies.go.jp", role = "aut")
   )
 Description: Fits multispecies site occupancy models to environmental DNA
     metabarcoding data collected using spatially-replicated survey design.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: occumb
 Title: Site Occupancy Modeling for Environmental DNA Metabarcoding
-Version: 1.1.0.9000
+Version: 1.1.0.9001
 Authors@R: c(
     person("Keiichi", "Fukaya", , "fukayak99@gmail.com", role = c("aut", "cre")),
     person("Ken", "Kellner", role = "cph",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
 ## occumb (development version)
+* Change error message for validate_occumbData 
+* Add a test to throw an error when integer is too large
+
+## occumb (development version)
 * Fix an issue with `sigma`'s default value.
 
 ## occumb 1.1.0 (2024/3/26)

--- a/R/occumbData.R
+++ b/R/occumbData.R
@@ -24,8 +24,13 @@ validate_occumbData <- function(object) {
         msg <- c(msg, "'y' contains missing value(s)")
 
     ## y elements are integers.
-    if (!checkmate::test_array(object@y, mode = "integerish"))
+    if (!checkmate::test_array(object@y, mode = "integerish")) {
+      if (is.numeric(object@y) & !checkmate::test_numeric(object@y, upper = .Machine$integer.max)) {
+        msg <- c(msg, "'y' contains value(s) exceeding maximum integer size")
+      } else {
         msg <- c(msg, "'y' contains non-integer value(s)")
+      }
+    }
 
     ## y elements are non-negative.
     if (!checkmate::test_integerish(object@y, lower = 0))

--- a/tests/testthat/test-occumbData.R
+++ b/tests/testthat/test-occumbData.R
@@ -25,8 +25,11 @@ test_that("Check for missing values for y works", {
 test_that("Integer check for y works", {
     expect_error(new("occumbData", y = array(1:8 + 0.1, dim = rep(2, 3))),
                  "'y' contains non-integer value")
-    expect_error(new("occumbData", y = array(c(Inf, 1:7), dim = rep(2, 3))),
+    expect_error(new("occumbData", y = array(c("1", 1:7), dim = rep(2, 3))),
                  "'y' contains non-integer value")
+    expect_error(new("occumbData", y = array(c(Inf, 1:7), dim = rep(2, 3))),
+                 "'y' contains value(s) exceeding maximum integer size",
+                 fixed = TRUE)
 })
 
 test_that("Check for non-negative values for y works", {


### PR DESCRIPTION
Previously, in occumb_test.script, the type 2 test for "yに正の実数を混入 (整数化可能だがintegerの最大値を超える)" passes but returns with an inappropriate error message "“occumbData” オブジェクト: 'y' contains non-integer value(s)." Therefore, I updated validate_occumbData() to throw an error message saying "'y' contains value(s) exceeding maximum integer size" specifically when the object is non-integer numeric and contained value(s) exceeding maximum integer size. Following that, I added a test to show it works. 