### PR TITLE
Fix bugs in `get_posterior`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: occumb
 Title: Site Occupancy Modeling for Environmental DNA Metabarcoding
-Version: 1.1.0.9010
+Version: 1.1.0.9011
 Authors@R: c(
     person("Keiichi", "Fukaya", , "fukayak99@gmail.com", role = c("aut", "cre")),
     person("Ken", "Kellner", role = "cph",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: occumb
 Title: Site Occupancy Modeling for Environmental DNA Metabarcoding
-Version: 1.1.0.9009
+Version: 1.1.0.9010
 Authors@R: c(
     person("Keiichi", "Fukaya", , "fukayak99@gmail.com", role = c("aut", "cre")),
     person("Ken", "Kellner", role = "cph",

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * Fix an issue with `sigma`'s default value.
 * Add 'data.frame' as an input of occumbData.
 * Fix a bug in attribute assignment in `get_post_samples` and `get_post_summary`.
+* Fixed `get_post_samples()` not to output a vector.
 
 ## occumb 1.1.0 (2024/3/26)
 * Add `predict()` method for `occumbFit` class.

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Add tests for `gof` under unbalanced designs
 * Fix an issue with `sigma`'s default value.
 * Add 'data.frame' as an input of occumbData.
+* Fix a bug in attribute assignment in `get_post_samples` and `get_post_summary`.
 
 ## occumb 1.1.0 (2024/3/26)
 * Add `predict()` method for `occumbFit` class.

--- a/R/get_posterior.R
+++ b/R/get_posterior.R
@@ -138,6 +138,9 @@ check_args_get_posterior <- function(fit, parameter) {
   samples_extracted <- eval(
     parse(text = paste0("fit@fit$sims.list$", parameter))
   )
+  if (is.vector(samples_extracted)) {
+    samples_extracted <- matrix(samples_extracted, ncol = 1)
+  }
 
   # Add attributes
   out <- add_attributes(samples_extracted, fit, parameter, "samples")

--- a/R/get_posterior.R
+++ b/R/get_posterior.R
@@ -310,10 +310,18 @@ add_attributes1 <- function(obj, dimension = c("i", "ij", "ijk"),
 
 add_attributes2 <- function(obj, covariate, dimnames_y, type) {
 
+  has_intercept_only <- function(covariate) {
+    if (is.array(covariate)) {
+      return(dim(covariate)[length(dim(covariate))] == 1)
+    } else {
+      return(identical(covariate, 1))
+    }
+  }
+
   if (type == "samples") {
     attr(obj, "dimension") <- c("Sample", "Species", "Effects")
 
-    if (identical(covariate, 1)) {
+    if (has_intercept_only(covariate)) {
       effect_name <- "(Intercept)"
     } else {
       effect_name <- dimnames(covariate)[[length(dim(covariate))]]
@@ -337,7 +345,7 @@ add_attributes2 <- function(obj, covariate, dimnames_y, type) {
   if (type == "summary") {
     attr(obj, "dimension") <- c("Species", "Effects")
 
-    if (identical(covariate, 1)) {
+    if (has_intercept_only(covariate)) {
       effect_name <- "(Intercept)"
     } else {
       effect_name <- dimnames(covariate)[[length(dim(covariate))]]

--- a/tests/testthat/test-get_posterior.R
+++ b/tests/testthat/test-get_posterior.R
@@ -47,6 +47,16 @@ fit2 <- occumb(formula_phi = ~ cov6,
                n.chains = 1, n.burnin = 5, n.thin = 1, n.iter = 10,
                verbose = FALSE)
 
+fit3 <- occumb(formula_phi = ~ 1,
+               formula_theta = ~ 1,
+               formula_psi = ~ 1,
+               formula_phi_shared = ~ cov6,
+               formula_theta_shared = ~ cov4,
+               formula_psi_shared = ~ cov3,
+               data = data_named,
+               n.chains = 1, n.burnin = 5, n.thin = 1, n.iter = 10,
+               verbose = FALSE)
+
 lpar <- c("z", "pi", "phi", "theta", "psi",
           "alpha", "beta", "gamma",
           "alpha_shared", "beta_shared", "gamma_shared",
@@ -374,6 +384,50 @@ test_that("Extracted samples and attributes are correct when proper parameter na
   expect_identical(test, ans)
 })
 
+test_that("$label$Effects attributes for alpha/beta/gamma are given correctly when site_cov or repl_cov is specified for shared parameters", {
+  ## Tests for alpha
+  i <- 6
+  test <- get_post_samples(fit3, lpar[i])
+  expect_identical(attributes(test)$dimension,
+                   c("Sample", "Species", "Effects"))
+  expect_identical(attributes(test)$label,
+                   list(Sample = NULL,
+                        Species = dimnames(data_named@y)[[1]],
+                        Effects = "(Intercept)"))
+  attr(test, "dimension") <- NULL
+  attr(test, "label") <- NULL
+  expect_identical(test,
+                   eval(parse(text = paste0("fit3@fit$sims.list$", lpar[i]))))
+
+  ## Tests for beta
+  i <- 7
+  test <- get_post_samples(fit3, lpar[i])
+  expect_identical(attributes(test)$dimension,
+                   c("Sample", "Species", "Effects"))
+  expect_identical(attributes(test)$label,
+                   list(Sample = NULL,
+                        Species = dimnames(data_named@y)[[1]],
+                        Effects = "(Intercept)"))
+  attr(test, "dimension") <- NULL
+  attr(test, "label") <- NULL
+  expect_identical(test,
+                   eval(parse(text = paste0("fit3@fit$sims.list$", lpar[i]))))
+
+  ## Tests for gamma
+  i <- 8
+  test <- get_post_samples(fit3, lpar[i])
+  expect_identical(attributes(test)$dimension,
+                   c("Sample", "Species", "Effects"))
+  expect_identical(attributes(test)$label,
+                   list(Sample = NULL,
+                        Species = dimnames(data_named@y)[[1]],
+                        Effects = "(Intercept)"))
+  attr(test, "dimension") <- NULL
+  attr(test, "label") <- NULL
+  expect_identical(test,
+                   eval(parse(text = paste0("fit3@fit$sims.list$", lpar[i]))))
+})
+
 ### Tests for get_post_summary -------------------------------------------------
 test_that("Extracted tables and attributes are correct when proper parameter names are given", {
 
@@ -654,4 +708,41 @@ test_that("Extracted tables and attributes are correct when proper parameter nam
   ans <- fit2@fit$summary[grep(paste0(lpar[i], "\\["), rownames(fit2@fit$summary)), ]
   expect_identical(test, ans)
 
+})
+test_that("$label$Effects attributes for alpha/beta/gamma are given correctly when site_cov or repl_cov is specified for shared parameters", {
+  ## Tests for alpha
+  i <- 6
+  test <- get_post_summary(fit3, lpar[i])
+  expect_identical(attributes(test)$dimension, c("Species", "Effects"))
+  expect_identical(attributes(test)$label,
+                   list(Species = dimnames(data_named@y)[[1]],
+                        Effects = "(Intercept)"))
+  attr(test, "dimension") <- NULL
+  attr(test, "label") <- NULL
+  ans <- fit3@fit$summary[grep(paste0(lpar[i], "\\["), rownames(fit3@fit$summary)), ]
+  expect_identical(test, ans)
+
+  ## Tests for beta
+  i <- 7
+  test <- get_post_summary(fit3, lpar[i])
+  expect_identical(attributes(test)$dimension, c("Species", "Effects"))
+  expect_identical(attributes(test)$label,
+                   list(Species = dimnames(data_named@y)[[1]],
+                        Effects = "(Intercept)"))
+  attr(test, "dimension") <- NULL
+  attr(test, "label") <- NULL
+  ans <- fit3@fit$summary[grep(paste0(lpar[i], "\\["), rownames(fit3@fit$summary)), ]
+  expect_identical(test, ans)
+
+  ## Tests for gamma
+  i <- 8
+  test <- get_post_summary(fit3, lpar[i])
+  expect_identical(attributes(test)$dimension, c("Species", "Effects"))
+  expect_identical(attributes(test)$label,
+                   list(Species = dimnames(data_named@y)[[1]],
+                        Effects = "(Intercept)"))
+  attr(test, "dimension") <- NULL
+  attr(test, "label") <- NULL
+  ans <- fit3@fit$summary[grep(paste0(lpar[i], "\\["), rownames(fit3@fit$summary)), ]
+  expect_identical(test, ans)
 })

--- a/tests/testthat/test-get_posterior.R
+++ b/tests/testthat/test-get_posterior.R
@@ -300,8 +300,11 @@ test_that("Extracted samples and attributes are correct when proper parameter na
                         Effects = c("cov22")))
   attr(test, "dimension") <- NULL
   attr(test, "label") <- NULL
-  expect_identical(test,
-                   eval(parse(text = paste0("fit1@fit$sims.list$", lpar[i]))))
+  expect_identical(
+    test,
+    matrix(eval(parse(text = paste0("fit1@fit$sims.list$", lpar[i]))),
+           ncol = 1)
+  )
   # Named y
   test <- get_post_samples(fit2, lpar[i])
   expect_identical(attributes(test)$dimension,
@@ -311,8 +314,11 @@ test_that("Extracted samples and attributes are correct when proper parameter na
                         Effects = c("cov22")))
   attr(test, "dimension") <- NULL
   attr(test, "label") <- NULL
-  expect_identical(test,
-                   eval(parse(text = paste0("fit2@fit$sims.list$", lpar[i]))))
+  expect_identical(
+    test,
+    matrix(eval(parse(text = paste0("fit2@fit$sims.list$", lpar[i]))),
+           ncol = 1)
+  )
 
   ## Tests for Mu/sigma
   for (i in 12:13) {


### PR DESCRIPTION
- Fixed a bug where `$label$Effects` of species-specific effects are not correctly specified when shared effects had a site or replicate covariate. 2720498415fe1df931ed24807603db267a961678
- Fixed `get_post_samples()` not (incorrectly) output posterior samples as a vector. 85daddff9ec30ad3da3aa059553fe5e16c1c2328