### PR TITLE
Fixes for JAGS 5.0.0

### DIFF
--- a/R/occumb.R
+++ b/R/occumb.R
@@ -445,12 +445,14 @@ inits_code <- function(const, margs, dat) {
 
   if (dat$prior_ulim > 10) {
     out <- c(out,
-             "         sigma    = stats::rnorm(margs$M, mean = 1, sd = 0.1))")
+             "         sigma    = stats::rnorm(margs$M, mean = 1, sd = 0.1),")
   } else {
     out <- c(out,
-             sprintf("         sigma    = stats::runif(margs$M, min = 0, max = %s))",
+             sprintf("         sigma    = stats::runif(margs$M, min = 0, max = %s),",
                      dat$prior_ulim))
   }
+  out <- c(out,
+           "         rho      = {rho <- matrix(NA, margs$M - 1, margs$M); rho[upper.tri(rho)] <- 0; rho})")
 
   out <- c(out, "}")
 

--- a/tests/testthat/test-occumb.R
+++ b/tests/testthat/test-occumb.R
@@ -230,7 +230,8 @@ test_that("Code for initial value function is correct for 144 available models",
              "         spec_eff = matrix(stats::rnorm(const$I * margs$M, sd = 0.1),",
              "                           const$I, margs$M),",
              "         Mu       = stats::rnorm(margs$M, sd = 0.1),",
-             "         sigma    = stats::rnorm(margs$M, mean = 1, sd = 0.1))",
+             "         sigma    = stats::rnorm(margs$M, mean = 1, sd = 0.1),",
+             "         rho      = {rho <- matrix(NA, margs$M - 1, margs$M); rho[upper.tri(rho)] <- 0; rho})",
              "}")
 
     res <- inits_code(const, margs, dat)
@@ -262,8 +263,9 @@ test_that("Code for initial value function is correct for 144 available models",
              "         Mu       = stats::rnorm(margs$M, sd = 0.1),")
 
     ans <- c(ans,
-             sprintf("         sigma    = stats::runif(margs$M, min = 0, max = %s))",
-                     dat$prior_ulim))
+             sprintf("         sigma    = stats::runif(margs$M, min = 0, max = %s),",
+                     dat$prior_ulim),
+             "         rho      = {rho <- matrix(NA, margs$M - 1, margs$M); rho[upper.tri(rho)] <- 0; rho})")
 
     ans <- c(ans, "}")
 


### PR DESCRIPTION
With the forthcoming release of JAGS 5.0.0, I am checking CRAN packages to ensure that they work with the new version. This patch resolves an issue with JAGS 5.0.0 and is back-compatible so that the patched version of occumb still works with the release version of JAGS, rjags and runjags.

JAGS 5.0.0 no longer chooses "typical" starting values for unobserved random variables but instead samples them from the prior distribution. In the occumb package this change causes problems for the variance covariance matrix Sigma in your jags template. There is nothing wrong with this prior as long as the model starts with a positive-definite matrix, but generating Sigma from the prior on sigma and rho will not do this (To be precise, it has a low probability of creating a valid positive-definite matrix). This patch fixes the initial values for the rho parameters to be equal to zero, which is the value chosen by default in JAGS 4.

Thank you for supporting JAGS with your work.